### PR TITLE
Don't show immediate messages for slash commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
 bundler_args: "--without=development"
 env:
   global:
+    - FERNET_SECRET=xBPxUfoJRRXOfA9Zol1v6qNmXMjj/vJHG5OUpceXnwQ=
     - DATABASE_URL=postgres://localhost/slash_heroku_test
 before_script:
 - psql -c 'create database slash_heroku_test;' -U postgres

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem "turbolinks"
 gem "uglifier", ">= 1.3.0"
 
 group :development, :test do
+  gem "brakeman"
   gem "byebug"
   gem "dotenv-rails"
   gem "pry"
@@ -37,7 +38,6 @@ group :test do
 end
 
 group :development do
-  gem "brakeman"
   gem "foreman"
   gem "spring"
   gem "web-console", "~> 3.0"

--- a/app/controllers/commands_controller.rb
+++ b/app/controllers/commands_controller.rb
@@ -4,8 +4,8 @@ class CommandsController < ApplicationController
   def create
     if slack_token_valid?
       if current_user
-        command = current_user.create_command_for(params)
-        render json: {response_type: "in_channel"}.to_json
+        current_user.create_command_for(params)
+        render json: { response_type: "in_channel" }.to_json
       else
         render json: authenticate_payload.to_json
       end

--- a/app/controllers/commands_controller.rb
+++ b/app/controllers/commands_controller.rb
@@ -5,7 +5,7 @@ class CommandsController < ApplicationController
     if slack_token_valid?
       if current_user
         command = current_user.create_command_for(params)
-        render json: command.default_response.to_json
+        render json: {response_type: "in_channel"}.to_json
       else
         render json: authenticate_payload.to_json
       end

--- a/spec/request/commands_spec.rb
+++ b/spec/request/commands_spec.rb
@@ -20,8 +20,7 @@ RSpec.describe "SlashHeroku /commands", type: :request do
     expect(status).to eql(200)
     response_body = JSON.parse(body)
     expect(response_body["response_type"]).to eql("in_channel")
-    expect(response_body["text"])
-      .to match(/Running\([^)]+\): 'help:default'\.\.\./)
+    expect(response_body["text"]).to eql(nil)
   end
 
   it "links to login + origin if you need to authenticate with Heroku" do


### PR DESCRIPTION
This removes the annoying "Running" message that serves no purposes with the response_url stuff working well.

### Before

![slack 2016-03-06 23-03-58](https://cloud.githubusercontent.com/assets/38/13562677/bd62e8b4-e3ef-11e5-83a8-fec4916e055a.png)

### After

![slack 2016-03-06 23-02-08](https://cloud.githubusercontent.com/assets/38/13562638/7ae3efa6-e3ef-11e5-86c5-0eb0f1e4d7cb.png)
