### PR TITLE
Add columns to eventually use with GitHub auth

### DIFF
--- a/db/migrate/20160317162544_add_github_token.rb
+++ b/db/migrate/20160317162544_add_github_token.rb
@@ -1,0 +1,6 @@
+class AddGithubToken < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :enc_github_token, :string, null: true
+    add_column :users, :github_login, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160305060400) do
+ActiveRecord::Schema.define(version: 20160317162544) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,8 @@ ActiveRecord::Schema.define(version: 20160305060400) do
     t.string   "slack_team_id",            null: false
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false
+    t.string   "enc_github_token"
+    t.string   "github_login"
   end
 
   add_foreign_key "commands", "users"


### PR DESCRIPTION
This add two columns:

* enc_github_token: For storing the oauth token encrypted
* github_login: For easier querying if we want to find users quickly.
