### PR TITLE
Set the KOLKRABBI_HOSTNAME env var

### DIFF
--- a/app.json
+++ b/app.json
@@ -79,6 +79,10 @@
     },
     "YUBIEXPIRE_HOSTNAME": {
       "description": "The hostname to post keys to to ensure everything gets invalidated at some point."
+    },
+    "KOLKRABBI_HOSTNAME": {
+      "description": "The hostname for Heroku's kolkrabbi service. Leave this alone.",
+      "value": "kolkrabbi.heroku.com"
     }
   },
   "formation": [


### PR DESCRIPTION
Without `KOLKRABBI_HOSTNAME` set, the escobar client makes all the deploy functions go :boom: like this:

> `/h wcid foo`
> Unable to fetch deployment info for envato-sites